### PR TITLE
Change default supermarket URL to chef.io domain

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-source "https://supermarket.getchef.com"
+source "https://supermarket.chef.io"
 
 metadata
 


### PR DESCRIPTION
While using this cookbook with a customer behind a SSL proxy, supermarket.getchef.com failed but supermarket.chef.io worked.  So making that the default.