### PR TITLE
Improvements when using package_source and better testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bin/*
 
 .kitchen/
 .kitchen.local.yml
+.kitchen.cloud.local.yml

--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -1,0 +1,157 @@
+#<% require 'kitchen-sync' %>
+---
+driver_config:
+  # digitalocean_access_token: <%= ENV['DIGITALOCEAN_API_TOKEN'] %>
+  # google_key_location: <%= ENV['GOOGLE_KEY_LOCATION'] %>
+  # google_project: <%= ENV['GOOGLE_PROJECT'] %>
+  # joyent_username: <%= ENV['SDC_CLI_ACCOUNT'] %>
+  # joyent_keyfile: <%= ENV['SDC_CLI_IDENTITY'] %>
+  # joyent_keyname: <%= ENV['SDC_CLI_KEY_ID'] %>
+  # joyent_url: <%= ENV['SDC_CLI_URL'] %>
+  aws_access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  aws_secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  aws_ssh_key_id: <%= ENV['AWS_KEYPAIR_NAME'] %>
+  instance_type: t2.medium
+  region: us-west-2
+  tags: { "X-Project": "Supermarket" }
+
+provisioner:
+  name: chef_zero
+  require_chef_omnibus: latest
+
+platforms:
+# - name: centos-5.8
+#   driver_plugin: digitalocean
+#   driver_config:
+#     size: 2gb
+#     image: centos-5-8-x64
+#     region: <%= ENV['DIGITALOCEAN_REGION'] %>
+#     ssh_key_ids: <%= ENV['DIGITALOCEAN_SSH_KEYS'] %>
+#     ssh_key: <%= ENV['DIGITALOCEAN_SSH_KEY_PATH'] %>
+
+# - name: centos-6.5
+#   driver_plugin: digitalocean
+#   driver_config:
+#     size: 2gb
+#     image: centos-6-5-x64
+#     region: <%= ENV['DIGITALOCEAN_REGION'] %>
+#     ssh_key_ids: <%= ENV['DIGITALOCEAN_SSH_KEYS'] %>
+#     ssh_key: <%= ENV['DIGITALOCEAN_SSH_KEY_PATH'] %>
+
+# - name: centos-7.0
+#   driver_plugin: digitalocean
+#   driver_config:
+#     size: 2gb
+#     image: centos-7-0-x64
+#     region: <%= ENV['DIGITALOCEAN_REGION'] %>
+#     ssh_key_ids: <%= ENV['DIGITALOCEAN_SSH_KEYS'] %>
+#     ssh_key: <%= ENV['DIGITALOCEAN_SSH_KEY_PATH'] %>
+
+- name: amazon-2014.09
+  driver_plugin: ec2
+  transport:
+    username: ec2-user
+    ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
+  driver_config:
+    image_id: ami-9a6ed3f2
+
+- name: redhat-6.6
+  driver_plugin: ec2
+  transport:
+    ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
+    username: ec2-user
+  driver_config:
+    image_id: ami-5fbcf36f
+
+- name: redhat-7.1
+  driver_plugin: ec2
+  transport:
+    username: ec2-user
+    ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
+  driver_config:
+    image_id: ami-4dbf9e7d
+
+# - name: fedora-21
+#   driver_plugin: digitalocean
+#   driver_config:
+#     size: 2gb
+#     image: fedora-21-x64
+#     region: <%= ENV['DIGITALOCEAN_REGION'] %>
+#     ssh_key_ids: <%= ENV['DIGITALOCEAN_SSH_KEYS'] %>
+#     ssh_key: <%= ENV['DIGITALOCEAN_SSH_KEY_PATH'] %>
+
+# - name: suse-11.3
+#   driver_plugin: ec2
+#   driver_config:
+#     image_id: ami-e8084981
+#     username: root
+#     ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
+
+# - name: debian-7.0
+#   driver_plugin: digitalocean
+#   driver_config:
+#     size: 2gb
+#     image: debian-7-0-x64
+#     region: <%= ENV['DIGITALOCEAN_REGION'] %>
+#     ssh_key_ids: <%= ENV['DIGITALOCEAN_SSH_KEYS'] %>
+#     ssh_key: <%= ENV['DIGITALOCEAN_SSH_KEY_PATH'] %>
+#   run_list:
+#   - recipe[apt]
+
+# - name: ubuntu-12.04
+#   driver_plugin: digitalocean
+#   driver_config:
+#     size: 2gb
+#     image: ubuntu-12-04-x64
+#     region: <%= ENV['DIGITALOCEAN_REGION'] %>
+#     ssh_key_ids: <%= ENV['DIGITALOCEAN_SSH_KEYS'] %>
+#     ssh_key: <%= ENV['DIGITALOCEAN_SSH_KEY_PATH'] %>
+#   run_list:
+#   - recipe[apt]
+
+# - name: ubuntu-14.04
+#   driver_plugin: digitalocean
+#   driver_config:
+#     size: 2gb
+#     image: ubuntu-14-04-x64
+#     region: <%= ENV['DIGITALOCEAN_REGION'] %>
+#     ssh_key_ids: <%= ENV['DIGITALOCEAN_SSH_KEYS'] %>
+#     ssh_key: <%= ENV['DIGITALOCEAN_SSH_KEY_PATH'] %>
+#   run_list:
+#   - recipe[apt]
+
+# - name: omnios-151006
+#   driver_plugin: ec2
+#   driver_config:
+#     image_id: ami-35eb835c
+#     flavor_id: m3.large
+#     username: root
+#     ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
+#   run_list:
+#   - recipe[ips-omniti]
+
+# - name: smartos-14.3.0
+#   driver_plugin: joyent
+#   driver_config:
+#     joyent_image_id: 62f148f8-6e84-11e4-82c5-efca60348b9f
+#     joyent_flavor_id: g3-standard-4-smartos
+#     username: root
+#     ssh_key: <%= ENV['SDC_CLI_IDENTITY'] %>
+#   busser:
+#     ruby_bindir: '/opt/local/bin/'
+#   provisioner:
+#     sudo: false
+#     chef_omnibus_url: https://raw.github.com/test-kitchen/kitchen-joyent/master/scripts/install-smartos.sh
+
+
+suites:
+  - name: default
+    run_list:
+      - recipe[supermarket-omnibus-cookbook::default]
+    attributes:
+      supermarket_omnibus:
+        chef_server_url: ~
+        chef_oauth2_app_id: ~
+        chef_oauth2_secret: ~
+        chef_oauth2_verify_ssl: ~
+

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,10 +17,18 @@ platforms:
     driver:
       network:
       - ["private_network", {ip: "33.33.33.21"}]
+  - name: centos-5.11
+    driver:
+      network:
+      - ["private_network", {ip: "33.33.33.24"}]
   - name: centos-6.6
     driver:
       network:
       - ["private_network", {ip: "33.33.33.25"}]
+  - name: centos-7.1
+    driver:
+      network:
+      - ["private_network", {ip: "33.33.33.28"}]
 
 suites:
   - name: default

--- a/Berksfile
+++ b/Berksfile
@@ -2,4 +2,6 @@ source "https://supermarket.chef.io"
 
 metadata
 
-cookbook 'chef-server-ingredient', git: 'https://github.com/chef-cookbooks/chef-server-ingredient.git'
+# because https://github.com/chef-cookbooks/chef-server-ingredient/pull/18
+#cookbook 'chef-server-ingredient', git: 'https://github.com/chef-cookbooks/chef-server-ingredient.git'
+cookbook 'chef-server-ingredient', git: 'https://github.com/irvingpop/chef-server-ingredient.git', branch: 'fix_package_providers'

--- a/Berksfile
+++ b/Berksfile
@@ -2,6 +2,5 @@ source "https://supermarket.chef.io"
 
 metadata
 
-# because https://github.com/chef-cookbooks/chef-server-ingredient/pull/18
+cookbook 'chef-server-ingredient', '~> 0.4.0'
 #cookbook 'chef-server-ingredient', git: 'https://github.com/chef-cookbooks/chef-server-ingredient.git'
-cookbook 'chef-server-ingredient', git: 'https://github.com/irvingpop/chef-server-ingredient.git', branch: 'fix_package_providers'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'all_rights'
 description      'Installs and Configures Supermarket from the Omnibus packages on packagecloud.io'
 source_url       'https://github.com/irvingpop/supermarket-omnibus-cookbook'
 issues_url       'https://github.com/irvingpop/supermarket-omnibus-cookbook/issues'
-version          '0.3.1'
+version          '0.3.2'
 
 
 depends 'chef-server-ingredient'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'all_rights'
 description      'Installs and Configures Supermarket from the Omnibus packages on packagecloud.io'
 source_url       'https://github.com/irvingpop/supermarket-omnibus-cookbook'
 issues_url       'https://github.com/irvingpop/supermarket-omnibus-cookbook/issues'
-version          '0.3.2'
+version          '0.4.0'
 
 
 depends 'chef-server-ingredient'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -94,4 +94,28 @@ describe 'supermarket-omnibus-cookbook::default' do
       chef_run # This should not raise an error
     end
   end
+
+  context 'When a package_source is specified, the Rpm provider should be used on RHEL systems' do
+    let(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(platform: 'redhat', version: '6.5', step_into: 'chef_server_ingredient') do |node|
+        # node.set['supermarket_package']['package_source']  = 'https://web-dl.packagecloud.io/chef/stable/packages/el/6/supermarket-1.10.1~alpha.0-1.el5.x86_64.rpm'
+        node.set['supermarket_package']['package_source']  = '/chef/stable/packages/el/6/supermarket-1.10.1~alpha.0-1.el5.x86_64.rpm'
+        node.set['supermarket_omnibus']['chef_server_url']    = 'https://chefserver.mycorp.com'
+        node.set['supermarket_omnibus']['chef_oauth2_app_id'] = 'blahblah'
+        node.set['supermarket_omnibus']['chef_oauth2_secret'] = 'bob_loblaw'
+      end
+      runner.converge(described_recipe)
+    end
+
+    it 'installs an Rpm package' do
+      stub_command("grep Fauxhai /etc/hosts").and_return('33.33.33.11 chefspec')
+      expect(chef_run).to install_rpm_package('supermarket')
+      expect(chef_run).to_not install_yum_package('supermarket')
+    end
+
+    it 'converges successfully' do
+      stub_command("grep Fauxhai /etc/hosts").and_return('33.33.33.11 chefspec')
+      chef_run # This should not raise an error
+    end
+  end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -15,8 +15,11 @@ describe 'supermarket-omnibus-cookbook::default' do
       runner.converge(described_recipe)
     end
 
-    it 'raises an error' do
+    before do
       stub_command("grep chefspec /etc/hosts").and_return('33.33.33.11 chefspec')
+    end
+
+    it 'raises an error' do
       expect { chef_run }.to raise_error(RuntimeError)
     end
 
@@ -32,8 +35,11 @@ describe 'supermarket-omnibus-cookbook::default' do
       runner.converge(described_recipe)
     end
 
-    it 'converges successfully' do
+    before do
       stub_command("grep chefspec /etc/hosts").and_return('33.33.33.11 chefspec')
+    end
+
+    it 'converges successfully' do
       chef_run # This should not raise an error
     end
   end
@@ -49,19 +55,20 @@ describe 'supermarket-omnibus-cookbook::default' do
       runner.converge(described_recipe)
     end
 
-    it 'uses the specified chef_server_ingredient[supermarket] with a repository of "chef/current"' do
+    before do
       stub_command("grep chefspec /etc/hosts").and_return('33.33.33.11 chefspec')
+    end
+
+    it 'uses the specified chef_server_ingredient[supermarket] with a repository of "chef/current"' do
       expect(chef_run).to install_chef_server_ingredient('supermarket')
         .with(repository: 'chef/current')
     end
 
     it 'creates a packagecloud_repository named "chef/current"' do
-      stub_command("grep chefspec /etc/hosts").and_return('33.33.33.11 chefspec')
       expect(chef_run).to create_packagecloud_repo('chef/current')
     end
 
     it 'converges successfully' do
-      stub_command("grep chefspec /etc/hosts").and_return('33.33.33.11 chefspec')
       chef_run # This should not raise an error
     end
   end
@@ -70,7 +77,7 @@ describe 'supermarket-omnibus-cookbook::default' do
   context 'When a package_source is specified, packagecloud should not be used' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new do |node|
-        node.set['supermarket_package']['package_source']  = 'http://bit.ly/98K8eH'
+        node.set['supermarket_package']['package_source']  = 'https://web-dl.packagecloud.io/chef/stable/packages/el/6/supermarket-1.10.1~alpha.0-1.el5.x86_64.rpm'
         node.set['supermarket_omnibus']['chef_server_url']    = 'https://chefserver.mycorp.com'
         node.set['supermarket_omnibus']['chef_oauth2_app_id'] = 'blahblah'
         node.set['supermarket_omnibus']['chef_oauth2_secret'] = 'bob_loblaw'
@@ -78,19 +85,20 @@ describe 'supermarket-omnibus-cookbook::default' do
       runner.converge(described_recipe)
     end
 
-    it 'uses the specified chef_server_ingredient[supermarket] with a package_source set' do
+    before do
       stub_command("grep chefspec /etc/hosts").and_return('33.33.33.11 chefspec')
+    end
+
+    it 'uses the specified chef_server_ingredient[supermarket] with a package_source set' do
       expect(chef_run).to install_chef_server_ingredient('supermarket')
-        .with(package_source: 'http://bit.ly/98K8eH')
+        .with(package_source: ::File.join(Chef::Config[:file_cache_path], 'supermarket-1.10.1-alpha.0-1.el5.x86_64.rpm'))
     end
 
     it 'does not create a packagecloud_repository named "chef/stable"' do
-      stub_command("grep chefspec /etc/hosts").and_return('33.33.33.11 chefspec')
       expect(chef_run).to_not create_packagecloud_repo('chef/stable')
     end
 
     it 'converges successfully' do
-      stub_command("grep chefspec /etc/hosts").and_return('33.33.33.11 chefspec')
       chef_run # This should not raise an error
     end
   end
@@ -98,8 +106,7 @@ describe 'supermarket-omnibus-cookbook::default' do
   context 'When a package_source is specified, the Rpm provider should be used on RHEL systems' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new(platform: 'redhat', version: '6.5', step_into: 'chef_server_ingredient') do |node|
-        # node.set['supermarket_package']['package_source']  = 'https://web-dl.packagecloud.io/chef/stable/packages/el/6/supermarket-1.10.1~alpha.0-1.el5.x86_64.rpm'
-        node.set['supermarket_package']['package_source']  = '/chef/stable/packages/el/6/supermarket-1.10.1~alpha.0-1.el5.x86_64.rpm'
+        node.set['supermarket_package']['package_source']  = 'https://web-dl.packagecloud.io/chef/stable/packages/el/6/supermarket-1.10.1~alpha.0-1.el5.x86_64.rpm'
         node.set['supermarket_omnibus']['chef_server_url']    = 'https://chefserver.mycorp.com'
         node.set['supermarket_omnibus']['chef_oauth2_app_id'] = 'blahblah'
         node.set['supermarket_omnibus']['chef_oauth2_secret'] = 'bob_loblaw'
@@ -107,14 +114,16 @@ describe 'supermarket-omnibus-cookbook::default' do
       runner.converge(described_recipe)
     end
 
-    it 'installs an Rpm package' do
+    before do
       stub_command("grep Fauxhai /etc/hosts").and_return('33.33.33.11 chefspec')
+    end
+
+    it 'installs an Rpm package' do
       expect(chef_run).to install_rpm_package('supermarket')
       expect(chef_run).to_not install_yum_package('supermarket')
     end
 
     it 'converges successfully' do
-      stub_command("grep Fauxhai /etc/hosts").and_return('33.33.33.11 chefspec')
       chef_run # This should not raise an error
     end
   end


### PR DESCRIPTION
* Download and cache the package when using package_source
* Simplify tests to make the stub_command more DRY
* add .kitchen.cloud.yml example for testing in EC2
* add CentOS 5 and 7 platforms for Vagrant testing
* switch back to using chef-server-ingredient from Supermarket now that version 0.4.0 has been released